### PR TITLE
Chat-Space_Automatic-Update

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function(){
   function buildHTML(message){
     if (message.image){
-      var html = `<div class="main-messages__message">
+      var html = `<div class="main-messages__message" data-message-id${message.id}>
                     <div class="main-messages__message__info">
                       <div class="main-messages__message__info__name">
                         ${message.user_name}
@@ -17,7 +17,7 @@ $(function(){
                   </div>`
       return html;
     } else {
-      var html = `<div class="main-messages__message">
+      var html = `<div class="main-messages__message" data-message-id=${message.id}>
                     <div class="main-messages__message__info">
                       <div class="main-messages__message__info__name">
                         ${message.user_name}
@@ -33,6 +33,7 @@ $(function(){
       return html;
     };
   }
+
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -54,6 +55,28 @@ $(function(){
     })
     .fail(function(){
       alert("メッセージ送信に失敗しました");
-  });
+    });
   })
+  $(function(){
+    var reloadMessages = function(){
+      var last_message_id = $('.main-messages__message:last').data("message-id");
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages){
+        var insertHTML = '';
+        $.each(messages, function(i,message){
+          insertHTML += buildHTML(message)
+        });
+        $('.main-messages').append(insertHTML);
+      })
+      .fail(function(){
+        alert('error');
+      });
+    };
+    setInterval(reloadMessages, 7000);
+  });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -67,16 +67,21 @@ $(function(){
         data: {id: last_message_id}
       })
       .done(function(messages){
+        if (messages.length !== 0){
         var insertHTML = '';
         $.each(messages, function(index,message){
           insertHTML += buildHTML(message)
         });
         $('.main-messages').append(insertHTML);
+        $('.main-messages').animate({ scrollTop: $('.main-messages')[0].scrollHeight});
+        }
       })
       .fail(function(){
         alert('error');
       });
     };
-    setInterval(reloadMessages, 7000);
+    if (document.location.href.match(/\/groups\/\d+\/messages/)){
+      setInterval(reloadMessages, 7000);
+    }
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -68,7 +68,7 @@ $(function(){
       })
       .done(function(messages){
         var insertHTML = '';
-        $.each(messages, function(i,message){
+        $.each(messages, function(index,message){
           insertHTML += buildHTML(message)
         });
         $('.main-messages').append(insertHTML);

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-messages__message
+.main-messages__message{data: {message: {id: message.id}}}
   .main-messages__message__info
     .main-messages__message__info__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
動作確認用
https://gyazo.com/533bb20ca975900221d2357ffa5cd86e

# 1.カスタムデータ属性
## What
メッセージのIDをカスタムデータ属性として追加。
## why
自動更新実装のため、個々のメッセージにID属性を付与する。
# 2.新規投稿の取得
## What
・新規メッセージ確認用のアクション追加。
・アクション呼び出せるようルーティングを追加。
## why
新規メッセージの投稿を取得するため。
# 3.投稿内容のレスポンス
## What
json形式で投稿内容をレスポンスできるよう追加変更。
## why
新規投稿内容をレスポンスするため。
# 4.取得した投稿データを表示
## What
・jQueryからAPIの呼び出し(reloadMessages)。
・buildHTMLメソッドにカスタムデータ属性の反映。
・数秒毎にリクエストをするようにsetInterval関数の追加。
## why
他ユーザーにも投稿データを反映させるため。
# 5.indexの意味
## What
メッセージの投稿された回数を表している(iだとわかりづらいのでindexに変更)。
## why
メモ用。
# 6.ブラッシュアップ
## What
・メッセージを取得すると最下部へスクロール。
・グループのメッセージ一覧ページのみで自動更新が行われるようにコード追加。
## why
機能面を充実させるため。